### PR TITLE
component.json: update dependency specifications

### DIFF
--- a/component.json/specifications.md
+++ b/component.json/specifications.md
@@ -103,6 +103,25 @@
 }
 ```
 
+  Each dependency must be defined in the following form:
+
+```
+"<user>/<repo>": "*|<reference>|<semver range>"
+```
+
+  A `*` wildcard dependency will try the following:
+
+  1. Use a version already included in the build
+  2. Use the latest tag release
+  3. Use the the main branch
+
+  Each reference can be:
+
+  - a `git` reference including:
+    - `<tag>`
+    - `<branch>` such as `master` or `gh-pages`
+    - `<commit>` sha
+
 ## .development
 
   Development dependencies. For example:


### PR DESCRIPTION
references: 
- https://github.com/component/component/issues/456
- https://github.com/component/component/issues/96
- https://github.com/component/component/issues/312
- https://github.com/component/component/issues/426
- https://github.com/component/component/issues/370 github releases!

some notes:
- semver will be handled by my `agent.http` specification, which i'll add later
- `<branch>` and `<commit>` references are only allowed in development.
  the registry should have a fit if there are any components with dependencies that use either.
- we should push people to actually use semantic versioning, i.e. `"component/emitter": "~1.1.1"`. if everyone pins, there are going to be duplicates. specifically, i want to force people to use `~x.x.x` syntax on dependencies with CSS because you can't have duplicate CSS. 
