### PR TITLE
components/<user>-<repo>@<version>

### DIFF
--- a/component-build/specifications.md
+++ b/component-build/specifications.md
@@ -1,5 +1,9 @@
-## component build
+# component build
 
   TODO: detail...
 
   For reference view the [JavaScript builder implementation](https://github.com/component/builder.js).
+
+## components/<user>-<repo>@<version>
+
+## components/<user>-<repo>@<branch>@<commit>


### PR DESCRIPTION
References: 
- https://github.com/component/component/issues/104
- https://github.com/component/component/issues/312
- https://github.com/component/component/issues/442

using `@` here because i think things will become confusing with non-version tags like:

``` bash
component-installer.js-generator
```

More distinct if we do:

``` bash
component-installer.js@generator
```

do folders handle `@`s though?
