### PR TITLE
potential registry and server spec

### DIFF
--- a/registry/implementation.md
+++ b/registry/implementation.md
@@ -1,0 +1,30 @@
+# Component Registry Implementation Notes
+
+  The registry is only meant to replace the [List of Components](https://github.com/component/component/wiki/Components) in its current form.
+
+## Validation
+
+  To make components higher quality, we want to validate components before they are added to the registry. We also want to normalize `component.json`s, such as expanding globs.
+
+## Component Releases
+
+  The registry requires components to have releases, specifically git tags. We do not want components that have no releases or releases that aren't semantic versions.
+
+  Git branches and commits must be handled by a server, not the registry.
+
+## Distributions
+
+  I expect the event source to be something like:
+
+```js
+event: 'data'
+data: {"name":"emitter","version":"1.1.1"}
+```
+
+  Idea is that we want the registry to be cheap (a single free Heroku instance). We can then have agents mirror the registry, and people listen to the mirrors, not the registry directly, creating a network of chains. It's not like you need to know about all updates immediately.
+
+## Adds and Updates
+
+  There are a couple of ways to send updates. A `component registry update` command would be nice to ping the registry to update. This is probably the easiest.
+
+  We can then add GitHub oAuth authentication that hooks into your repos and sends an update command to the registry every time a tag is pushed.

--- a/registry/specifications.md
+++ b/registry/specifications.md
@@ -1,7 +1,62 @@
-## Registry
+# Component Registry Specifications
 
-  Components are currently fetched from Github, however in the future we may allow for completely swapping out the registry, as well as multiple registry support.
-  This means alternative registries __MUST__ comply with the Github-style urls following:
+  The purpose of a registry is to catalog a set of components. Every registry __must__ have a set of criteria for components to be added to the registry. For example, Component's default registry will be for web components, and every component must either have `scripts`, `styles`, or any other web-related file consumable by a browser.
 
-  - `GET /:user/:project/master/:file` to fetch files for `*`, otherwise the same as below
-  - `GET /:user/:project/:version/:file` to fetch a file's contents (`GET /component/tip/0.0.1/component.json`)
+  Registries only store components' metadata, specifically their `component.json`. It notifies clients and agents how to download the component, but it does not serve the actual components.
+
+## GET /components
+
+Returns all components in the registry.
+
+## GET /registry
+
+  Returns `registry.json`, the details of the registry.
+
+- `.name` [required] - the name of the registry. The registry must match the following regular expression: `/^[a-z-]{3,}$/`.
+- `.hostname` [optional] - its hostname without any protocols or slashes, i.e. `component.io`
+
+## GET /tail
+
+  Return an [EventSource](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) stream. Every time a component releases a new version, the registry __must__ send that `component.json` to all listening clients.
+
+## GET /:user/:project
+
+  Returns the project's latest release's `component.json`.
+
+  The following properties are added:
+
+  - `releases[]` - a list of valid releases. Each `release` has the following properties:
+    - `release` - the name of the release.
+    - `version` - the version of the release, if any.
+
+## GET /:user/:project/:release
+
+  Returns a release's `component.json`.
+
+## PUT /:user/:project
+
+  Add a project to the registry.
+
+  The registry __must__ validate the component's `component.json` and reject the component if it does not comply.
+
+  The registry __must__ reject the component if it does not have any semantically versioned releases.
+
+  The registry __may__ add additional requirements on the component.
+
+  The registry __should__ normalize the component as applicable.
+
+## PATCH /:user/:project
+
+  Update a project's metadata from its source. The registry then __must__ updates the project's list of releases, if any.
+
+  The registry __must__ validate every new release.
+
+  If updated, the registry __must__ push the latest release's `component.json` to all clients listing on `/tail`.
+
+## DELETE /:user/:project
+
+  Deletes a project from the registry.
+  Aside from authorization, this request __should__ be valid only if any of the following criteria are met:
+
+  - The project no longer exists at the source
+  - The project is not a valid component in the registry

--- a/server/implementation.md
+++ b/server/implementation.md
@@ -1,0 +1,96 @@
+## Component Server Implementation Notes
+
+  Philosophically, each server can be considered an [npmd](https://github.com/dominictarr/npmd) instance.
+
+## GET /components
+
+  Right now, every client recursively resolves the dependencies of all the components. This is annoying because:
+
+- It requires an excessive amount of HTTP requests
+- It's slow
+- There's no caching involved
+- Single point of failure (GitHub)
+
+  Since `server`s have a list of components and their releases in the registry, it should be able to resolve all a build's dependencies without a single HTTP request (unless you're using branches or commits).
+
+  When the `server` is on the local host, this is effectively the same thing, but with caching.
+
+## GET /:user/:project/:reference
+
+  Contents is mirrored by GitHub's API.
+
+  Idea behind multiple URLs is to allow mirroring. A `server` could tell the client to download a file directly from GitHub raw or another `server` instead of itself.
+
+## /build and /components
+
+  Maybe. Something like how [c8](https://github.com/gingkoapp/c8) works right now, but with `GET /components`' API.
+
+## Transformations
+
+  I expect the server to be able to do transformations, but I don't think it belongs in the specification. For example, we can do the following transformation to avoid concatenating every file to a build:
+
+```
+GET  /component/emitter/1.1.1/index.js?cjs
+```
+
+```js
+modules['component/emitter@1.1.1'] = function (module, exports, require) {
+  // ...
+}
+```
+
+  Then instead of an install and build process, component can have a tool that outputs script tags appropriately that you just include in your template:
+
+```html
+<script src="/components/require.js"></script>
+<script src="http://component.io/component/emitter/1.1.1/index.js?cjs"></script>
+<script src="http://component.io/component/domify/1.1.1/index.js?cjs"></script>
+<script src="/app/boot/index.js"></script>
+```
+
+  Now there's no build process. This basically eliminates the need for AMD, and due to Component's builder, there's no path resolution users have to worry about. No `../../../client/index.js` crap.
+
+  We can also do `UMD` wraps, so people just write CommonJS modules, and we'll wrap it in that silly UMD wrap for them. This will encourage people to write CJS instead of AMD or any weird or custom build systems people use.
+
+  The installation process only resolves dependencies which could be done with a single HTTP request to a `server`. If you have a server locally, we're talking about `< 50ms` installation times if everything is cached.
+
+  Since each file is downloaded from a CDN, it's much faster than doing `bower install` or `npm install`.
+
+  However, you should still be able to download the components locally, but you should only have to do it when you're making a production build or debugging your dependencies.
+
+## component.io
+
+  `http://component.io` will be a CDN in front of a `server`. We can run it behind a single free Heroku instance and put a CloudFlare in front of it.
+
+  The cool part is that we've effectively replaced [cdnjs](https://github.com/cdnjs/cdnjs) and every other cdn like it, such as [bootstrapcdn](http://www.bootstrapcdn.com). Updates to `component.io` will happen automatically unlike cdnjs. Look at all those issues and PRs it has.
+
+  It's also very useable. With a URL like `http://component.io/jquery/jquery/2.0.3/jquery.js`, people know exactly where the repository is and what file version it is. Non-component people will benefit.
+
+  I don't think `component.io` should bother with branch or commit releases - we can require people to use their own local server to support that. In fact, we should always encourage people to use their own local server. We just have to make sure it's easy.
+
+## Deployment
+
+  Servers are ephemeral since they are "backed" by a registry. Thus, we can just cache everything locally in the file system. If the server dies or crashes, just spin up a new instance and it'll redownload everything.
+
+  Servers won't need a database, making deployment easy. We can store `registry.json` in memory since it should be small. If we do need a database, we can use an embedded one like leveldb.
+
+## If we do this, Component will win.
+
+  Component is a full-stack solution, but it is modular so you can use many different parts of it.
+
+- You might want to skip the 100s of script tags and just go for a build process (like we do currently).
+- Maybe you just want to use component's CDN on a really simple static site.
+- Maybe you only want to use it as a build process and deployment tool for your open source library
+
+  Reasons I think Component will win:
+
+- People will use the CDN, which is free marketing and free for us
+- People will be inclined to include a `component.json` in their repos even if they don't use component.
+    - They can push their code to a CDN just by tagging a new release, making it easier for people to use their code.
+    - They can write CJS while supporting AMD and globals as well
+    - They don't need to make any releases or include it in their git repo
+- People would use it just for dependency and file management and automatically creating script and style tags. This is basically what Bower currently does, but we'll do it better
+- Great usability due to GitHub integration and namespaces
+- No lengthy install process unlike every other package manager
+- It would eliminate the need for AMD. Just write CJS and Component will handle the rest. AMD people concat and minify their files anyways, so there won't be any compelling reason to use AMD anymore.
+- Relatively easy migration to ES6 (I think, not sure, but it's an important goal)

--- a/server/specifications.md
+++ b/server/specifications.md
@@ -1,0 +1,60 @@
+# Component Server Specifications
+
+  The server is the middleman between clients, the component sources (such as GitHub), and the registry. The server could be on the local host, a server on the network, a proxy, or an official site. The server:
+
+  - Caches components locally
+  - Resolves build dependencies
+  - Is cheap and ephemeral
+
+## GET /server
+
+  Return information about this server:
+
+  - `registries` [required] - registries' `registry.json` which the server is capable of handling. Each server __must__ implement at least one registry. Registries __must__ be listed in descending priority.
+  - `hostname` [optional] - the hostname of this server clients __should__ use.
+
+## GET /components
+
+  Resolves the dependencies of a list of components.
+  The client __must__ send a list of projects to build.
+
+  The server __must__ respond with all components in the build in the correct order. Each component __must__ include all data corresponding to a `GET /:user/:project/:reference` request.
+
+  The server __must__ include all dependencies in the response.
+
+## GET /components/:project.tar
+
+  The server __must__ redirect to a valid location to download the component's latest semantically versioned release __or__ serve the component directly.
+
+## GET /:user/:project/:reference
+
+  The server __must__ support the component's releases as a `reference` and any semantic version ranges.
+  The `server` __should__ support branches and commits.
+
+  If a version if satisfied, it must return that project's `component.json`.
+
+  The response should add the following properties:
+
+  - `contents[]` - an array of all files in the component. Each `content` must have the following properties:
+    - `mode`
+    - `type` - `blob` or `dir`
+    - `sha` - `sha1` sum
+    - `path` - path
+    - `size` - byte size of the file
+    - `urls[]` - an array URLs where the file can be downloaded. When downloading the file, the client __must__ try each `url` in the order specified.
+  - `tarballs[]` - an array of tarballs where the project can be downloaded. Each tarball must have the following properties:
+    - `sha` - `sha`
+    - `size` - `size`
+    - `url` - URL of the tarball. When downloading the tarball, the client __must__ try each `url` in the order specified.
+
+  If `registry.hostname` is not defined, each `url` __must__ be an absolute or protocol-relative URL.
+
+## GET /:user/:project/:reference.tar
+
+  Downloads the project in a tar ball. The server __must not__ include any files not explicitly listed in `component.json`.
+
+## GET /:user/:project/:reference/*
+
+  Download each file of a project directly.
+
+  The `server` __must__ allow downloading files from valid releases. The `server` __should__ allow downloading files from semver, branch, or commit releases.


### PR DESCRIPTION
here's my thoughts on a component registry and server. not sure what your current plans are @visionmedia 

the main takeaways are:
- separated registry and server
- no pushing releases to a registry like npm - everything is pulled from a source (such as GitHub) or cached locally on a server

i've also included some notes on a potential no-build system. this is really only useful for JS since we rework/autoprefix our CSS anyways. the more i think about it though, the more complicated it gets, but i think it's the direction we'd go when implementing ES6 modules.

(note: i plan to remove everything in implementations.md once we move it out of the spec)
