### PR TITLE
component 0.19.7 start make use of templates

### DIFF
--- a/component.json/specifications.md
+++ b/component.json/specifications.md
@@ -17,7 +17,8 @@
     "component/emitter": "*",
     "component/jquery": "*"
   },
-  "scripts": ["index.js", "template.js"],
+  "templates" : ["template.html"],
+  "scripts": ["index.js"],
   "styles": ["tip.css"],
   "license": "MIT"
 }


### PR DESCRIPTION
Component convert is removed at 0.19.8. The old script would make user confusing.
