### PR TITLE
fix example of requiring templates

### DIFF
--- a/component.json/specifications.md
+++ b/component.json/specifications.md
@@ -189,7 +189,7 @@ The __public__ component __should__ have semantic versioned dependencies.
 ## .templates
 
   The templates array __MUST__ provide the contents of each file as a require-able module.
-  For example the following must provide the HTML string via `require('user.html')`.
+  For example the following must provide the HTML string via `require('./user.html')`.
   If you're using `component-build` the files will be converted automatically using the [string plugin](https://github.com/component/builder2.js/blob/master/docs/scripts.md#string) of builder2.
 
 ```json


### PR DESCRIPTION
if one want's to use the short alias, templates can only be required within a component via the ´./´prefix. without it, ´require()´ing fails (because during build it won't get replaced by the canonical name).
