### PR TITLE
Make reference to ".repo" alias

### DIFF
--- a/component.json/specifications.md
+++ b/component.json/specifications.md
@@ -38,6 +38,8 @@
 
 ## .repository
 
+  alias: .repo
+
   The __public__ component __MUST__ have a "repository" property,
   this is registry end-point consisting of `<username>/<project>`,
   for example "visionmedia/page.js" or "component/dialog".


### PR DESCRIPTION
It seems that the Component team often use this alias (e.g. [tap](https://github.com/component/tap/blob/576b92dbdc110f45dff693951c9184107344f9d5/component.json#L3), [assert](https://github.com/component/assert/blob/c636e751f22199f2ef454d7a3ce36218799375eb/component.json#L3), and [reactive](https://github.com/component/reactive/blob/17b35a3de774d657205a9ec6bca53be92cd1ed78/component.json#L3)).
